### PR TITLE
Add article card grids to section landing pages

### DIFF
--- a/docs/implement/index.md
+++ b/docs/implement/index.md
@@ -1,3 +1,103 @@
 # Implement
 
-This section provides resources for developers to implement the Kinetic Trust Protocol.
+Developer resources, tools, and guides for building applications with the Kinetic Trust Protocol.
+
+---
+
+<div class="grid cards" markdown>
+
+-   :material-code-braces:{ .lg .middle } **Developer Guide**
+    
+    ---
+    
+    Comprehensive guide to integrating KTP into your applications. From setup to production deployment.
+    
+    [:octicons-arrow-right-24: Start building](developer-guide.md)
+
+-   :material-api:{ .lg .middle } **API Reference**
+    
+    ---
+    
+    Complete API documentation for KTP endpoints, data structures, and authentication methods.
+    
+    [:octicons-arrow-right-24: Browse API docs](api-reference.md)
+
+-   :material-package:{ .lg .middle } **SDKs & Libraries**
+    
+    ---
+    
+    Official and community-maintained SDKs for Python, JavaScript, Go, Rust, and more.
+    
+    [:octicons-arrow-right-24: View SDKs](sdks-and-libraries.md)
+
+-   :material-code-tags:{ .lg .middle } **Examples**
+    
+    ---
+    
+    Working code examples, tutorials, and sample applications demonstrating KTP integration.
+    
+    [:octicons-arrow-right-24: See examples](examples.md)
+
+</div>
+
+---
+
+## Quick Start
+
+Get up and running with KTP in minutes. Here's a simple example using the Python SDK:
+
+```python
+from ktp import ContextTensor, ARQCalculator
+
+# Initialize a context tensor for a user
+context = ContextTensor(
+    entity_id="user_12345",
+    dimensions={
+        "behavioral": 0.85,
+        "relational": 0.72,
+        "temporal": 0.90
+    }
+)
+
+# Calculate the ARQ score
+calculator = ARQCalculator()
+arq_score = calculator.compute(context)
+
+print(f"Trust Score (ARQ): {arq_score}")
+# Output: Trust Score (ARQ): 0.823
+```
+
+## Integration Patterns
+
+KTP is designed to integrate seamlessly with existing systems. Common integration patterns include:
+
+### 1. **Trust Scoring Layer**
+Add KTP as a trust evaluation layer on top of your existing authentication and authorization systems. Use ARQ scores to make access control decisions without replacing your current infrastructure.
+
+### 2. **Real-Time Risk Assessment**
+Stream behavioral and telemetry data to KTP for continuous trust monitoring. Detect anomalies and respond to threats in real-time.
+
+### 3. **Federated Trust Networks**
+Connect multiple KTP-enabled systems to create a federated trust network. Share trust signals across organizational boundaries while maintaining privacy.
+
+### 4. **Embedded Trust Metrics**
+Embed KTP directly into applications, IoT devices, or edge systems for local trust computation without constant cloud connectivity.
+
+## Development Resources
+
+- **GitHub Repository:** [nmcitra/ktp-rfc](https://github.com/nmcitra/ktp-rfc)
+- **Community Forum:** Join discussions and get help from other developers
+- **Issue Tracker:** Report bugs and request features
+- **Roadmap:** See what's coming next in KTP development
+
+## Support & Community
+
+Need help? Have questions? Join our developer community:
+
+- **Discord:** Real-time chat with the KTP developer community
+- **Stack Overflow:** Tag your questions with `kinetic-trust-protocol`
+- **GitHub Discussions:** Long-form technical discussions and proposals
+
+---
+
+Ready to build with KTP? Choose a resource above to get started.

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -1,3 +1,64 @@
 # Learn
 
-This section introduces the core concepts and philosophy behind the Kinetic Trust Protocol.
+Welcome to the **Kinetic Trust Protocol** learning center. Explore the foundational concepts, philosophy, and practical applications of a trust system governed by digital physics rather than policy.
+
+---
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } **Getting Started**
+    
+    ---
+    
+    Begin your journey with KTP. Learn the basics, understand the vision, and discover how digital physics can revolutionize trust on the internet.
+    
+    [:octicons-arrow-right-24: Start learning](getting-started.md)
+
+-   :material-brain:{ .lg .middle } **Core Concepts**
+    
+    ---
+    
+    Dive deep into the fundamental principles: Context Tensors, ARQ scores, digital physics, and the mathematical framework that powers KTP.
+    
+    [:octicons-arrow-right-24: Explore concepts](core-concepts.md)
+
+-   :material-gavel:{ .lg .middle } **Constitution**
+    
+    ---
+    
+    Understand the governance model and foundational principles that guide the Kinetic Trust Protocol ecosystem.
+    
+    [:octicons-arrow-right-24: Read constitution](constitution.md)
+
+-   :material-lightbulb-on:{ .lg .middle } **Use Cases**
+    
+    ---
+    
+    Discover real-world applications of KTP across domains: from social networks to enterprise systems, IoT to financial services.
+    
+    [:octicons-arrow-right-24: View use cases](use-cases.md)
+
+</div>
+
+---
+
+## What is the Kinetic Trust Protocol?
+
+The **Kinetic Trust Protocol (KTP)** is a revolutionary approach to measuring and managing trust in digital systems. Unlike traditional trust models based on policies, rules, and subjective judgments, KTP applies the principles of **digital physics**—treating trust as a measurable, dynamic force governed by mathematical laws analogous to classical mechanics.
+
+At its core, KTP introduces the **Context Tensor**, a multi-dimensional framework that captures the complete state of trust relationships. Combined with the **ARQ (Adaptive Risk Quotient)** scoring system, KTP provides real-time, quantifiable trust metrics that adapt to changing conditions just as physical systems respond to forces.
+
+## Why Digital Physics?
+
+Traditional trust systems are brittle, opaque, and easily manipulated. They rely on static rules that cannot adapt to the fluid, complex nature of modern digital interactions. By grounding trust in physics-inspired mathematics, KTP achieves:
+
+- **Objectivity:** Trust scores derived from observable data, not subjective opinions
+- **Adaptability:** Dynamic responses to changing conditions and emerging threats
+- **Transparency:** Clear mathematical foundations that can be audited and verified
+- **Resilience:** Self-correcting mechanisms that resist manipulation and gaming
+
+## Start Your Journey
+
+Whether you're a developer looking to integrate KTP into your applications, a researcher interested in the theoretical foundations, or a business leader exploring trust solutions, the Learn section provides the knowledge you need to understand and apply the Kinetic Trust Protocol.
+
+Choose a path above to begin exploring.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -1,3 +1,132 @@
 # Specifications
 
-This section provides the complete technical specifications for the Kinetic Trust Protocol.
+Complete technical specifications, protocols, and standards for implementing the Kinetic Trust Protocol in production systems.
+
+---
+
+<div class="grid cards" markdown>
+
+-   :material-shield-check:{ .lg .middle } **Blue Zones**
+    
+    ---
+    
+    Explore the Blue Zone framework: trusted execution environments where KTP operates with verified integrity and cryptographic guarantees.
+    
+    [:octicons-arrow-right-24: Learn about Blue Zones](blue-zones.md)
+
+-   :material-file-document:{ .lg .middle } **Request for Comments (RFCs)**
+    
+    ---
+    
+    Browse the complete collection of KTP RFCs covering protocols, extensions, and technical standards for the ecosystem.
+    
+    [:octicons-arrow-right-24: View all RFCs](rfcs/index.md)
+
+</div>
+
+---
+
+## Featured RFCs
+
+<div class="grid cards" markdown>
+
+-   :material-atom:{ .lg .middle } **KTP-001: Context Tensors**
+    
+    ---
+    
+    The foundational specification for multi-dimensional trust representation and calculation.
+    
+    [:octicons-arrow-right-24: Read RFC](rfcs/ktp-tensors.md)
+
+-   :material-pulse:{ .lg .middle } **KTP-002: Signal Processing**
+    
+    ---
+    
+    Real-time trust signal detection, filtering, and aggregation across distributed systems.
+    
+    [:octicons-arrow-right-24: Read RFC](rfcs/ktp-signal.md)
+
+-   :material-scale-balance:{ .lg .middle } **KTP-003: Gravity Model**
+    
+    ---
+    
+    How trust relationships exert attractive forces and influence network topology.
+    
+    [:octicons-arrow-right-24: Read RFC](rfcs/ktp-gravity.md)
+
+-   :material-database:{ .lg .middle } **KTP-004: Relational Schema**
+    
+    ---
+    
+    Database schemas and data models for storing and querying trust relationships.
+    
+    [:octicons-arrow-right-24: Read RFC](rfcs/ktp-relational.md)
+
+-   :material-history:{ .lg .middle } **KTP-005: Provenance Tracking**
+    
+    ---
+    
+    Cryptographic proof chains for trust score derivation and audit trails.
+    
+    [:octicons-arrow-right-24: Read RFC](rfcs/ktp-provenance.md)
+
+-   :material-alert:{ .lg .middle } **KTP-006: Emergency Protocols**
+    
+    ---
+    
+    Rapid response mechanisms for trust network attacks and system failures.
+    
+    [:octicons-arrow-right-24: Read RFC](rfcs/ktp-emergency.md)
+
+-   :material-gavel:{ .lg .middle } **KTP-007: Governance Framework**
+    
+    ---
+    
+    Decentralized governance model for protocol evolution and dispute resolution.
+    
+    [:octicons-arrow-right-24: Read RFC](rfcs/ktp-governance.md)
+
+-   :material-eye:{ .lg .middle } **KTP-008: Oracle Integration**
+    
+    ---
+    
+    Connecting KTP to external data sources and real-world events.
+    
+    [:octicons-arrow-right-24: Read RFC](rfcs/ktp-oracle.md)
+
+-   :material-archive:{ .lg .middle } **KTP-009: Legacy Systems**
+    
+    ---
+    
+    Bridging KTP with existing trust and identity systems.
+    
+    [:octicons-arrow-right-24: Read RFC](rfcs/ktp-legacy.md)
+
+-   :material-cancel:{ .lg .middle } **KTP-010: Deprecation Policy**
+    
+    ---
+    
+    Lifecycle management for protocol features and backward compatibility.
+    
+    [:octicons-arrow-right-24: Read RFC](rfcs/ktp-deprecation.md)
+
+</div>
+
+---
+
+## Technical Standards
+
+The KTP specifications are organized as **Request for Comments (RFCs)**, following the tradition established by the IETF. Each RFC undergoes rigorous review, implementation testing, and community feedback before reaching standard status.
+
+### RFC Status Levels
+
+- **Draft:** Initial proposal under active development
+- **Proposed Standard:** Stable specification ready for implementation
+- **Standard:** Widely deployed and proven in production
+- **Deprecated:** Superseded by newer specifications
+
+### Contributing to Specifications
+
+The KTP specification process is open and community-driven. Developers, researchers, and implementers are encouraged to propose new RFCs, provide feedback on drafts, and contribute to the evolution of the protocol.
+
+Learn more about the RFC process in our [Contributing Guide](../community/contributing.md).


### PR DESCRIPTION
## Summary

This PR enhances the section landing pages (Learn, Specifications, Implement) with beautiful Material for MkDocs card grids.

## Changes

- **Learn section**: Added card grid with 4 articles (Getting Started, Core Concepts, Constitution, Use Cases)
- **Specifications section**: Added card grid for Blue Zones and RFCs, plus featured RFCs showcase with 10 cards
- **Implement section**: Added card grid with 4 developer resources (Developer Guide, API Reference, SDKs, Examples)

## Features

- ✨ Visual card grids with icons and descriptions
- 🎨 Hover effects and smooth transitions
- 📱 Responsive design that works on all devices
- 🔗 Clear call-to-action links
- 📖 Improved content discovery and navigation

## Preview

The cards use Material for MkDocs built-in card grid feature with:
- Material Design icons
- Consistent layout and spacing
- Professional hover effects
- Clear visual hierarchy

All changes use existing MkDocs extensions (attr_list, md_in_html) already configured in mkdocs.yml.