### PR TITLE
UpdatesDocs: refine trust dimensions and fix footer URLs

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -8,9 +8,20 @@ window.MathJax = {
   options: {
     ignoreHtmlClass: ".*|",
     processHtmlClass: "arithmatex"
+  },
+  startup: {
+    ready: () => {
+      MathJax.startup.defaultReady();
+      MathJax.startup.promise.then(() => {
+        console.log('MathJax initial typesetting complete');
+      });
+    }
   }
 };
 
 document$.subscribe(() => {
-  MathJax.typesetPromise()
-})
+  if (typeof MathJax !== 'undefined' && MathJax.typesetPromise) {
+    MathJax.typesetPromise()
+      .catch((err) => console.log('MathJax typeset error:', err));
+  }
+});

--- a/docs/learn/core-concepts.md
+++ b/docs/learn/core-concepts.md
@@ -184,34 +184,38 @@ To enforce the Zeroth Law, KTP must measure both A (action risk) and E (environm
 
 1. :material-star-four-points-circle: The complete Context Tensor specification spans 1,707 dimensions. See [KTP-TENSORS](../rfcs/ktp-tensors.md) for measurement definitions, aggregation rules, and instrumentation requirements.
 
-### The Six Domains (1,707 dimensions)
+### The Seven Dimensions of Trust
 
-| Tensor | Dimensions | Core Question |
-|--------|------------|---------------|
-| **Soul** | 252 | Who is this agent becoming? |
-| **Body** | 157 | What resources does it have? |
-| **World** | 387 | What surrounds it? |
-| **Time** | 291 | When and how fast? |
-| **Relational** | 262 | Who is it connected to? |
-| **Signal** | 358 | What does it know? |
+The Context Tensor expresses trust across seven primary dimensions—each measurable, each contributing to the system's live trust geometry:
 
-**Total: 1,707 dimensions** measuring the full operational context.
+| Dimension | Icon | What It Measures | Example Signals | Behavioral Effect |
+|-----------|------|------------------|-----------------|-------------------|
+| **Mass** | :material-database: | Telemetry density and volume | Request volume, throughput, concurrent sessions | Establishes baseline stability; "weight" of the environment |
+| **Momentum** | :material-trending-up: | Direction and velocity of change | Trust deltas, rapid swings, step changes | Captures acceleration; prevents trust whiplash |
+| **Inertia** | :material-sine-wave: | Resistance to rapid shifts | Config stability, dependency consistency, service criticality | Dampens noise for high-impact systems |
+| **Heat** | :material-thermometer: | Environmental stress and anomaly load | Error spikes, adversarial indicators, resource contention | Fast signal that decays slowly; triggers dormancy |
+| **Time** | :material-clock: | Temporal context and decay | Session duration, latency trends, freshness windows | Governs trust decay and refresh cycles |
+| **Observer** | :material-eye: | Who is watching and view reliability | Audit coverage, peer visibility, attestations | Independent observers raise confidence |
+| **Soul** | :material-creation: | Constitutional constraints (non-negotiables) | Consent flags, jurisdictional vetoes, sovereignty labels | Hard vetoes that bypass numerical scoring |
 
-### Cross-Cutting Physics Lenses
+!!! tip "Dimension Interaction"
+    These dimensions don't operate in isolation. For example, high **Heat** combined with low **Inertia** creates rapid trust collapse, while high **Mass** with stable **Momentum** indicates a healthy, predictable system.
 
-Context Tensors also roll up into physics-style lenses that inform the Trust Equation and Risk Deflation:
+### Dimension-to-RFC Tensor Mapping
 
-| Physics Lens | Core Question | RFC Tensor Mapping | Example Signals | Why it matters |
-|--------------|---------------|--------------------|-----------------|----------------|
-| **Mass** | Volume and density of telemetry | Body + World | Packet rates, occupancy, RF absorption | Establishes how “heavy” the environment is; sets baseline stability. |
-| **Momentum** | Rate of change in trust | Time + Signal | Trust velocity, confidence deltas, surge patterns | Captures acceleration of trust up/down to prevent whiplash. |
-| **Inertia** | Resistance to trust fluctuation | Body + Relational | Service criticality, blast radius, dependency depth | Dampens sudden shifts for high-impact systems; enforces stability. |
-| **Heat** | Operational stress and anomaly detection | World + Signal | Error bursts, adversarial scans, resource contention | Reveals pressure that should lower autonomy or trigger dormancy. |
-| **Time** | Temporal patterns and decay | Time | Phase of event, freshness, decay curves | Governs how long trust holds and when it should decay or refresh. |
-| **Observer** | Perspective and vantage point | Relational + Signal | Audience, stakeholder expectations, locality | Adjusts trust by who is impacted and from where it’s measured. |
-| **Soul** | Constitutional constraints that cannot be overridden | Soul | Sovereignty labels, TK/OCAP/CARE rules | Hard vetoes enforced before any other calculation. |
+The seven dimensions aggregate signals from underlying RFC tensor categories (totaling 1,707 individual measurements):
 
-See the full tensor definitions and rollups in [KTP-TENSORS](../rfcs/ktp-tensors.md#tensor-explorer).
+| Dimension | Primary RFC Tensors | Core Question | Aggregation Pattern |
+|-----------|---------------------|---------------|---------------------|
+| **Mass** | Body + World | How "heavy" is the environment? | Volume normalization across infrastructure telemetry |
+| **Momentum** | Time + Signal | How fast is trust changing? | Delta calculation with exponential smoothing |
+| **Inertia** | Body + Relational | How resistant to rapid shifts? | Stability index based on drift and churn penalties |
+| **Heat** | World + Signal | How much stress is present? | Stress accumulation from errors and anomalies |
+| **Time** | Time | When and how fresh? | Temporal windowing with exponential decay |
+| **Observer** | Relational + Signal | Who is watching? | Observer-weighted coverage scoring |
+| **Soul** | Soul | What cannot be overridden? | Constitutional gate with veto authority |
+
+See the full tensor definitions and rollups in [KTP-TENSORS](../rfcs/ktp-tensors.md#tensor-explorer) and [Context Tensor](context-tensor.md) for deep dives into each dimension.
 
 ### Measurement Principles
 

--- a/docs/overrides/partials/footer.html
+++ b/docs/overrides/partials/footer.html
@@ -26,42 +26,42 @@
       <section class="ktp-footer__nav">
         <h4>Learn</h4>
         <ul>
-          <li><a href="/learn/">Learn Home</a></li>
-          <li><a href="/learn/getting-started/">Getting Started</a></li>
-          <li><a href="/learn/context-tensor/">Context Tensor</a></li>
-          <li><a href="/learn/telemetry/">Telemetry</a></li>
-          <li><a href="/learn/use-cases/">Use Cases</a></li>
+          <li><a href="/ktp-rfc/learn/">Learn Home</a></li>
+          <li><a href="/ktp-rfc/learn/getting-started/">Getting Started</a></li>
+          <li><a href="/ktp-rfc/learn/context-tensor/">Context Tensor</a></li>
+          <li><a href="/ktp-rfc/learn/telemetry/">Telemetry</a></li>
+          <li><a href="/ktp-rfc/learn/use-cases/">Use Cases</a></li>
         </ul>
       </section>
 
       <section class="ktp-footer__nav">
         <h4>Specifications</h4>
         <ul>
-          <li><a href="/specifications/">Specs Home</a></li>
-          <li><a href="/specifications/blue-zones/">Blue Zones</a></li>
-          <li><a href="/rfcs/">RFCs</a></li>
-          <li><a href="/schemas/">Schemas</a></li>
+          <li><a href="/ktp-rfc/specifications/">Specs Home</a></li>
+          <li><a href="/ktp-rfc/specifications/blue-zones/">Blue Zones</a></li>
+          <li><a href="/ktp-rfc/rfcs/">RFCs</a></li>
+          <li><a href="/ktp-rfc/schemas/">Schemas</a></li>
         </ul>
       </section>
 
       <section class="ktp-footer__nav">
         <h4>Implement</h4>
         <ul>
-          <li><a href="/implement/">Implement Home</a></li>
-          <li><a href="/implement/api-reference/">API Reference</a></li>
-          <li><a href="/implement/sdks-and-libraries/">SDKs & Libraries</a></li>
-          <li><a href="/implement/examples/">Examples</a></li>
+          <li><a href="/ktp-rfc/implement/">Implement Home</a></li>
+          <li><a href="/ktp-rfc/implement/api-reference/">API Reference</a></li>
+          <li><a href="/ktp-rfc/implement/sdks-and-libraries/">SDKs & Libraries</a></li>
+          <li><a href="/ktp-rfc/implement/examples/">Examples</a></li>
         </ul>
       </section>
 
       <section class="ktp-footer__nav">
         <h4>Resources</h4>
         <ul>
-          <li><a href="/">Home</a></li>
-          <li><a href="/community/">Community Home</a></li>
-          <li><a href="/community/writings/">Writings</a></li>
-          <li><a href="/community/tools/">Tools</a></li>
-          <li><a href="/community/contributing/">Contributing</a></li>
+          <li><a href="/ktp-rfc/">Home</a></li>
+          <li><a href="/ktp-rfc/community/">Community Home</a></li>
+          <li><a href="/ktp-rfc/community/writings/">Writings</a></li>
+          <li><a href="/ktp-rfc/community/tools/">Tools</a></li>
+          <li><a href="/ktp-rfc/community/contributing/">Contributing</a></li>
         </ul>
       </section>
     </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,7 +149,6 @@ extra:
       name: GitHub
 
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - javascripts/mathjax.js
   - javascripts/telemetry-table-details.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
Reframed core-concepts.md around seven trust dimensions with new tables, examples, and RFC mappings.
Hardened MathJax boot in mathjax.js with startup hook, logging, and guarded typesetting to avoid errors.
Pointed footer nav links in footer.html to the /ktp-rfc/ base path.
Removed the unused ES6 polyfill from mkdocs.yml extra scripts.
Testing: Not run (not requested).