### PR TITLE
Fix trust-tier canon: drop phantom architect tier, fold Hibernation into Observer

### DIFF
--- a/docs/implement/api-reference.md
+++ b/docs/implement/api-reference.md
@@ -115,7 +115,7 @@ Request a cryptographically signed trust proof for an agent.
 |-------|------|-------------|
 | `proof_id` | string | Unique proof identifier |
 | `trust_score` | integer | Effective trust score ($E_{trust}$), 0-100 |
-| `tier` | string | Trust tier: `observer`, `analyst`, `operator`, `architect`, `god-mode` |
+| `tier` | string | Trust tier: `observer`, `analyst`, `operator`, `god-mode` |
 | `e_base` | integer | Base trust score, 0-100 |
 | `risk_factor` | float | Environmental risk factor ($R$), 0.0-1.0 |
 | `expires_at` | timestamp | Proof expiration (typically 30 seconds) |
@@ -480,7 +480,7 @@ Exceeding rate limits returns `429 Too Many Requests`.
   "proof_id": "string (uuid)",
   "agent_id": "string",
   "trust_score": "integer (0-100)",
-  "tier": "enum(observer|analyst|operator|architect|god-mode)",
+  "tier": "enum(observer|analyst|operator|god-mode)",
   "e_base": "integer (0-100)",
   "e_trust": "integer (0-100)",
   "risk_factor": "float (0.0-1.0)",

--- a/docs/learn/risk.md
+++ b/docs/learn/risk.md
@@ -199,17 +199,10 @@ Different trust tiers have different risk tolerances. As risk increases, agents 
     </div>
   </div>
   <div class="risk-tier risk-tier--observer">
-    <div class="risk-tier-badge">≤50%</div>
+    <div class="risk-tier-badge">>30%</div>
     <div class="risk-tier-content">
       <strong>Observer</strong>
-      <span>Read-only enforcement</span>
-    </div>
-  </div>
-  <div class="risk-tier risk-tier--hibernation">
-    <div class="risk-tier-badge">>50%</div>
-    <div class="risk-tier-content">
-      <strong>Hibernation</strong>
-      <span>Dormant, no actions permitted</span>
+      <span>Read-only enforcement, then dormant — the agent hibernates and awaits recovery</span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Aligns the docs with the Constitution's four-tier ladder (God Mode / Operator / Analyst / Observer<70; Observer hibernates at the floor).

- `docs/implement/api-reference.md`: remove `architect` from the tier table + enum
- `docs/learn/risk.md`: fold the separate Hibernation tier into the Observer floor

Once merged, the ktp site's next build re-syncs this content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)