### PR TITLE
Add provenance infrastructure: NOTICE, CITATION.cff, PROVENANCE.md

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,21 @@
+{
+  "title": "Kinetic Trust Protocol (KTP): RFC Series",
+  "description": "KTP is a framework for dynamic, physics-based authorization of autonomous agents, replacing static permission models with environmental constraints that adapt in real time. This archive contains the RFC specification series.",
+  "creators": [
+    {
+      "name": "Perkins, Chris",
+      "orcid": "0009-0003-5479-4248"
+    }
+  ],
+  "license": "Apache-2.0",
+  "upload_type": "publication",
+  "publication_type": "technicalnote",
+  "access_right": "open",
+  "keywords": [
+    "agentic AI",
+    "authorization",
+    "trust",
+    "runtime governance",
+    "autonomous agents"
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: >-
+  KTP is free to use, implement, modify, and commercialize under the
+  Apache License 2.0. When your work materially uses or discusses KTP's
+  named constructs, equations, or distinctive architecture, please cite
+  this work.
+title: "Kinetic Trust Protocol (KTP): RFC Series"
+authors:
+  - family-names: "Perkins"
+    given-names: "Chris"
+    orcid: "https://orcid.org/0009-0003-5479-4248"
+version: "1.0.0"
+date-released: "2025-12-01"
+url: "https://github.com/nmcitra/ktp-rfc"
+repository-code: "https://github.com/nmcitra/ktp-rfc"
+license: "Apache-2.0"
+keywords:
+  - agentic-ai
+  - authorization
+  - trust
+  - runtime-governance
+  - autonomous-agents

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025-2026 Chris Perkins
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,37 @@
+Kinetic Trust Protocol (KTP)
+Copyright 2025-2026 Chris Perkins.
+
+KTP was first publicly released in November 2025 (v1.0.0 tagged 2025-12-01),
+developed under the New Mexico Cyber Intelligence & Threat Response Alliance
+(NMCITRA).
+
+Canonical source:
+https://github.com/nmcitra/ktp-rfc
+
+Preferred attribution:
+Chris Perkins, "Kinetic Trust Protocol (KTP): RFC Series,"
+Version 1.0.0, December 2025.
+https://github.com/nmcitra/ktp-rfc
+
+KTP is an open framework for environment-sensitive, physics-based
+authorization of autonomous agents.
+
+Distinctive constructs presented as part of the KTP architecture include:
+
+- The Zeroth Law: A <= E
+- Trust is Mass
+- Risk is Friction
+- Authorization is Motion
+- Identity is Trajectory
+- the Context Tensor
+- the Silent Veto
+- Digital Gravity
+- Blue Zones
+- the Trust Equation: E_trust = E_base x (1 - R)
+
+This notice identifies the provenance of the KTP specification and its
+architectural terminology. It does not claim exclusive ownership of general
+ideas, standard engineering concepts, or independently developed methods.
+
+See PROVENANCE.md for the full attribution and citation norms this project
+asks of downstream use.

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,52 @@
+# Attribution and Provenance
+
+KTP is intended to be freely used.
+
+You do not need permission from Chris Perkins to implement, modify, study,
+test, criticize, commercialize, or extend KTP, subject to the Apache
+License 2.0 (see `LICENSE`).
+
+## When citation is requested
+
+Please cite KTP when your work materially uses or discusses:
+
+- the KTP Zeroth Law, `A ≤ E`;
+- the KTP formulation "Trust is Mass";
+- "Risk is Friction" as part of the KTP model;
+- "Authorization is Motion";
+- "Identity is Trajectory";
+- the KTP Context Tensor;
+- the Silent Veto;
+- Digital Gravity as defined by KTP;
+- KTP Blue Zones;
+- the KTP Trust Equation (`E_trust = E_base × (1 - R)`);
+- or the combined KTP environment-first architecture.
+
+Preferred citation is in `CITATION.cff` and at the top of `README.md`.
+
+## What KTP does not claim
+
+KTP does not claim ownership of broad concepts such as:
+
+- runtime governance;
+- admissibility;
+- authorization;
+- invariants;
+- policy enforcement;
+- identity;
+- trust;
+- risk;
+- environmental context;
+- or continuous evaluation.
+
+Those concepts have substantial prior art and may be independently
+developed. The requested citation concerns KTP's distinctive expression,
+terminology, equations, and architectural synthesis — not the underlying
+ideas, which no license or notice can or should try to own.
+
+## Why this file exists
+
+This is a transparent scholarly norm, not an additional license condition.
+It exists so that omitting KTP from a genealogy of "convergent" or
+"complementary" frameworks that materially draws on this architecture is a
+visible choice, not a defensible accident.


### PR DESCRIPTION
## Summary
- Fills in the LICENSE copyright placeholder (was `[yyyy] [name of copyright owner]`)
- Adds NOTICE, CITATION.cff, and PROVENANCE.md to activate Apache 2.0's existing attribution machinery for KTP's named constructs (A≤E, Trust is Mass, Context Tensor, etc.)
- Adds .zenodo.json for DOI archival metadata on the next tagged release

## Test plan
- [ ] Confirm CITATION.cff renders GitHub's "Cite this repository" widget once merged to main
- [ ] Zenodo-GitHub integration toggle needs enabling in Zenodo account settings (one-time, manual) before a tagged release will auto-archive