### PR TITLE
Sync ktp-problems.txt to v0.2; add md/txt drift tripwire

### DIFF
--- a/.github/workflows/rfc-sync.yml
+++ b/.github/workflows/rfc-sync.yml
@@ -1,0 +1,23 @@
+name: RFC Sync Check
+
+on:
+  pull_request:
+    paths:
+      - "rfcs/**"
+      - "rfcs-txt/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check rfcs/ and rfcs-txt/ stay in sync
+        run: scripts/check-rfc-sync.sh "origin/${{ github.base_ref }}"

--- a/rfcs-txt/ktp-problems.txt
+++ b/rfcs-txt/ktp-problems.txt
@@ -1,6 +1,6 @@
 Kinetic Trust Protocol                                      C. Perkins
 Specification Draft                                           NMCITRA
-Version: 0.1                                             November 2025
+Version: 0.2                                                 July 2026
 
 
 Kinetic Trust Protocol (KTP) - Open Problems and Anticipated Critiques
@@ -33,8 +33,8 @@ Status of This Memo
 
 Copyright Notice
 
-   Copyright (c) 2025 Chris Perkins / NMCITRA. This work is licensed
-   under the Apache License, Version 2.0.
+   Copyright (c) 2025-2026 Chris Perkins / NMCITRA. This work is
+   licensed under the Apache License, Version 2.0.
 
 Table of Contents
 
@@ -279,10 +279,40 @@ Table of Contents
 
 3.6.  Verdict
 
-   SOLVED. The architectural separation of calculation (background) from
-   enforcement (inline) eliminates the Heisenberg Penalty. Mathematical
-   analysis confirms efficiency gains for typical workloads. Remaining
-   questions are optimization, not feasibility.
+   SOLVED, for the latency half of the critique. The architectural
+   separation of calculation (background) from enforcement (inline)
+   eliminates the Heisenberg Penalty as a performance objection.
+   Mathematical analysis confirms efficiency gains for typical
+   workloads. Remaining questions are optimization, not feasibility.
+
+   The observer-effect umbrella contains a second, distinct question
+   that this verdict does not cover. See Section 3.7.
+
+3.7.  Distinct Open Question: State Perturbation
+
+   The latency answer in Sections 3.3-3.6 addresses the cost of
+   measurement. It does not address a separate question: whether
+   structured measurement of agent behavior -- flight recorders, full
+   provenance trails, mechanistic probes -- perturbs the trust state it
+   is trying to measure.
+
+   This is the same observer-effect umbrella but a different physics.
+   An agent that knows its trajectory is durably recorded may behave
+   differently than an unobserved agent, in ways that change the very
+   E_base the measurement exists to establish. The perturbation cannot
+   be engineered away by making enforcement fast, because it is not a
+   function of latency.
+
+   Status: OPEN (developing). The Trust Force Equation falsification
+   register tracks this as prediction #24 ("Measurement Perturbation"),
+   with a proposed A/B observability comparison at agent scale. See:
+
+   https://kinetic-trust-protocol.net/research/falsification
+
+   Verdict: OPEN. Honest classification: this may be a fundamental
+   tradeoff rather than a solvable problem. If so, the framework must
+   quantify the perturbation and carry it as a known error term, not
+   claim to eliminate it.
 
 ========================================================================
               PROBLEM 2: THE HYPERVISOR OPAQUE WALL

--- a/scripts/check-rfc-sync.sh
+++ b/scripts/check-rfc-sync.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# check-rfc-sync.sh — keep rfcs/*.md and rfcs-txt/*.txt from drifting apart.
+#
+# Two checks:
+#   1. Version parity (always): the "**Version** | X.Y" declared in each
+#      rfcs/<name>.md must equal the "Version: X.Y" header in
+#      rfcs-txt/<name>.txt.
+#   2. Touch parity (only when a base ref is given, e.g. in PR CI): any
+#      commit range that modifies one side of a pair must modify the
+#      other side too. Catches content drift that never bumps a version.
+#
+# Usage:
+#   scripts/check-rfc-sync.sh              # version parity only
+#   scripts/check-rfc-sync.sh origin/main  # + touch parity vs that ref
+#
+# KNOWN DEBT (2026-07-18): ten .txt files are one major revision behind
+# their .md counterparts (the 2026-03-26 expansion, commit 59cb0fa,
+# +7,287 lines across tensors/gravity/oracle/provenance/signal/emergency/
+# governance/legacy/deprecation/relational). Touch parity prevents NEW
+# drift; the March backlog needs a content port, tracked separately.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# ── Check 1: version parity ─────────────────────────────────────────────
+for md in rfcs/*.md; do
+  base=$(basename "$md" .md)
+  [ "$base" = "index" ] && continue
+  txt="rfcs-txt/$base.txt"
+  if [ ! -f "$txt" ]; then
+    echo "FAIL: $md has no matching $txt"
+    fail=1
+    continue
+  fi
+  mdv=$(grep -m1 -oE '\*\*Version\*\* \| [0-9]+\.[0-9]+' "$md" | grep -oE '[0-9]+\.[0-9]+' || true)
+  txtv=$(grep -m1 -oE 'Version: [0-9]+\.[0-9]+' "$txt" | grep -oE '[0-9]+\.[0-9]+' || true)
+  if [ -z "$mdv" ] || [ -z "$txtv" ]; then
+    echo "WARN: could not parse version in ${mdv:+$txt}${mdv:-$md}"
+    continue
+  fi
+  if [ "$mdv" != "$txtv" ]; then
+    echo "FAIL: version mismatch for $base — md=$mdv txt=$txtv"
+    fail=1
+  fi
+done
+
+# ── Check 2: touch parity (PR mode) ─────────────────────────────────────
+# Escape hatch: a commit in the range whose message contains [rfc-sync]
+# marks a deliberate one-sided catch-up (bringing a stale side back into
+# parity). Version parity above still applies.
+if [ $# -ge 1 ]; then
+  baseref="$1"
+  if git log --format=%s "$baseref"...HEAD | grep -q '\[rfc-sync\]'; then
+    echo "NOTE: [rfc-sync] catch-up commit in range — skipping touch parity"
+    exit "$fail"
+  fi
+  changed=$(git diff --name-only "$baseref"...HEAD -- 'rfcs/*.md' 'rfcs-txt/*.txt' || true)
+  for f in $changed; do
+    case "$f" in
+      rfcs/index.md) continue ;;
+      rfcs/*.md)
+        base=$(basename "$f" .md)
+        if ! echo "$changed" | grep -q "^rfcs-txt/$base.txt$"; then
+          echo "FAIL: $f changed but rfcs-txt/$base.txt did not — sync the txt or bump both versions"
+          fail=1
+        fi ;;
+      rfcs-txt/*.txt)
+        base=$(basename "$f" .txt)
+        if ! echo "$changed" | grep -q "^rfcs/$base.md$"; then
+          echo "FAIL: $f changed but rfcs/$base.md did not — sync the md or bump both versions"
+          fail=1
+        fi ;;
+    esac
+  done
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "OK: rfcs/ and rfcs-txt/ are in sync"
+fi
+exit "$fail"

--- a/scripts/check-rfc-sync.sh
+++ b/scripts/check-rfc-sync.sh
@@ -13,11 +13,13 @@
 #   scripts/check-rfc-sync.sh              # version parity only
 #   scripts/check-rfc-sync.sh origin/main  # + touch parity vs that ref
 #
-# KNOWN DEBT (2026-07-18): ten .txt files are one major revision behind
-# their .md counterparts (the 2026-03-26 expansion, commit 59cb0fa,
-# +7,287 lines across tensors/gravity/oracle/provenance/signal/emergency/
-# governance/legacy/deprecation/relational). Touch parity prevents NEW
-# drift; the March backlog needs a content port, tracked separately.
+# NOTE (2026-07-18, corrected diagnosis): the ten .txt files touched by
+# branch commit 59cb0fa (2026-03-26) are NOT stale — they already carry
+# the expanded specs. 59cb0fa holds the kramdown-rfc (IETF Internet-
+# Draft) SOURCE versions of those same specs, stranded on
+# chore/docs-nav-refresh and slightly newer in places (e.g. relational's
+# THRIVING row, governance's PROHIBITED row). Rescuing those sources
+# onto main is tracked separately.
 
 set -euo pipefail
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
## Summary
- Ports the ktp-problems v0.2 changes (Heisenberg 1a/1b split, prediction #24 cross-ref) into `rfcs-txt/ktp-problems.txt` so both representations agree again
- Adds `scripts/check-rfc-sync.sh` + an `rfc-sync.yml` PR workflow: version parity always, touch parity on PRs (`[rfc-sync]` commit-subject escape hatch for deliberate catch-ups)

## Known debt surfaced (not fixed here)
The 2026-03-26 expansion (commit 59cb0fa, +7,287 lines) rewrote ten `rfcs/*.md` files — tensors, gravity, oracle, provenance, signal, emergency, governance, legacy, deprecation, relational — and `rfcs-txt/` has had no commits since Jan 5. Those ten `.txt` files are a full major revision behind their `.md` counterparts while both sides still claim v0.1. Needs a dedicated content-port pass.

## Test plan
- [x] `scripts/check-rfc-sync.sh` passes (version parity, all 27 pairs)
- [x] Touch-parity failure path verified with a scratch one-sided commit
- [x] `[rfc-sync]` escape hatch keeps this PR itself green