### PR TITLE
Refresh stale README (links, counts, structure, provenance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
 # Kinetic Trust Protocol (KTP) - RFC Series
 
-**Status**: Draft Specification - NMCITRA  
-**Version**: 0.1  
-**Date**: November 2025
+**Status**: Draft Specification — NMCITRA  
+**First published**: November 2025  
+**Last updated**: July 2026
 
 This repository contains draft specifications developed by the New Mexico
 Cyber Intelligence & Threat Response Alliance (NMCITRA). These documents
 have not been submitted to the IETF and do not represent Internet Standards
 or consensus of any standards body.
+
+> **Documentation site:** the full specifications render at
+> <https://nmcitra.github.io/ktp-rfc/>. Each RFC below links to its
+> summary page in `rfcs/`, which embeds the complete specification text
+> from `rfcs-txt/`.
+
+> **Citing KTP:** KTP is free to use, implement, and commercialize under
+> Apache 2.0. When your work materially uses KTP's named constructs or
+> architecture, please cite it — see [`CITATION.cff`](CITATION.cff) and
+> [`PROVENANCE.md`](PROVENANCE.md).
 
 > *"We cannot command Nature except by obeying her."* — Francis Bacon
 
@@ -52,76 +62,87 @@ This is not a policy. It is a physical constraint enforced by cryptography.
 
 ## RFC Series
 
-This repository contains 19 RFC documents comprising the complete KTP specification:
+This repository contains 27 RFC documents plus the Constitution, comprising
+the complete KTP specification. Each link points to the RFC's summary page in
+`rfcs/`, which embeds the full specification text.
 
 ### Foundational Documents
 
 | Document | Title | Lines | Description |
 |----------|-------|-------|-------------|
-| [Constitution](constitution.txt) | Constitution of Digital Physics | 693 | Preamble and 10 Articles defining the governing framework |
-| [KTP-CORE](rfcs/ktp-core.txt) | Core Protocol | 2,038 | Trust Score, Context Tensor, Trust Proof, Silent Veto, Anti-Goodhart measures |
+| [Constitution](constitution.txt) | Constitution of Digital Physics | 781 | Preamble and 10 Articles defining the governing framework |
+| [KTP-Core](rfcs/ktp-core.md) | Core Protocol | 1,761 | Trust Score, Context Tensor, Trust Proof, Silent Veto, Anti-Goodhart measures |
 
 ### Identity & Trust
 
 | RFC | Title | Lines | Description |
 |-----|-------|-------|-------------|
-| [KTP-IDENTITY](rfcs/ktp-identity.txt) | Vector Identity | 1,512 | Trajectory Chains, Proof of Resilience, Sponsorship, NIST 800-63 Identity Proofing |
-| [KTP-SENSORS](rfcs/ktp-sensors.txt) | Context Tensor Sensors | 1,050 | Sensor specifications, Risk Domains (Node/Neighborhood/Global), normalization, domain profiles |
+| [KTP-Identity](rfcs/ktp-identity.md) | Vector Identity | 1,472 | Trajectory Chains, Proof of Resilience, Sponsorship, NIST 800-63 Identity Proofing |
+| [KTP-Tensors](rfcs/ktp-tensors.md) | Context Tensor Specification | 840 | The measurement framework: dimensions across the six domains |
+| [KTP-Sensors](rfcs/ktp-sensors.md) | Context Tensor Sensors | 984 | Sensor specifications, Risk Domains, normalization, domain profiles |
+| [KTP-Signal](rfcs/ktp-signal.md) | Signal Environment | 599 | Information-environment measurement, truth conditions, epistemic health |
 
 ### Enforcement & Audit
 
 | RFC | Title | Lines | Description |
 |-----|-------|-------|-------------|
-| [KTP-ENFORCE](rfcs/ktp-enforce.txt) | Enforcement Layer | 1,186 | Policy Enforcement Points, Trust Tiers, Adaptive Dormancy, Mass Ceiling |
-| [KTP-AUDIT](rfcs/ktp-audit.txt) | Flight Recorder | 876 | Decision Geometry, immutable logging, forensics, counterfactual analysis |
+| [KTP-Gravity](rfcs/ktp-gravity.md) | Digital Gravity | 774 | Gravity wells, constraint types, real-time enforcement, the physics of denial |
+| [KTP-Enforce](rfcs/ktp-enforce.md) | Enforcement Layer | 1,234 | Policy Enforcement Points, Trust Tiers, Adaptive Dormancy, Mass Ceiling |
+| [KTP-Audit](rfcs/ktp-audit.md) | Flight Recorder | 1,044 | Decision Geometry, immutable logging, forensics, counterfactual analysis |
+| [KTP-Emergency](rfcs/ktp-emergency.md) | Emergency & Circuit Breakers | 1,110 | Emergency levels, circuit breakers, graceful degradation, zone collapse |
 
 ### Zones & Federation
 
 | RFC | Title | Lines | Description |
 |-----|-------|-------|-------------|
-| [KTP-ZONES](rfcs/ktp-zones.txt) | Blue Zone Discovery | 1,176 | Zone types (Deep Blue → Wild), discovery protocols, ingress/egress |
-| [KTP-FEDERATION](rfcs/ktp-federation.txt) | Trust Federation | 904 | Inter-zone trust, cross-attestation, federation governance |
+| [KTP-Zones](rfcs/ktp-zones.md) | Blue Zones & Trust Boundaries | 1,273 | Zone types (Deep Blue → Wild), discovery protocols, ingress/egress |
+| [KTP-Federation](rfcs/ktp-federation.md) | Trust Federation | 1,124 | Inter-zone trust, cross-attestation, federation governance |
+| [KTP-Oracle](rfcs/ktp-oracle.md) | Oracle Mesh | 1,000 | Trust Oracle mesh, consensus, threshold signatures, accountability |
 
 ### Technical Infrastructure
 
 | RFC | Title | Lines | Description |
 |-----|-------|-------|-------------|
-| [KTP-CRYPTO](rfcs/ktp-crypto.txt) | Cryptographic Specification | 1,456 | Algorithms, key management, HSM requirements, post-quantum strategy |
-| [KTP-TRANSPORT](rfcs/ktp-transport.txt) | Transport Layer | 1,398 | Wire formats, REST/gRPC APIs, real-time protocols, WebSocket streams |
-| [KTP-THREAT-MODEL](rfcs/ktp-threat-model.txt) | Threat Model | 1,756 | STRIDE analysis, attack trees, risk assessment, security requirements |
+| [KTP-Crypto](rfcs/ktp-crypto.md) | Cryptographic Specification | 1,538 | Algorithms, key management, HSM requirements, post-quantum strategy |
+| [KTP-Transport](rfcs/ktp-transport.md) | Transport Layer | 1,423 | Wire formats, REST/gRPC APIs, real-time protocols, WebSocket streams |
+| [KTP-Threat-Model](rfcs/ktp-threat-model.md) | Threat Model | 1,580 | STRIDE analysis, attack trees, risk assessment, security requirements |
 
 ### Operations & Recovery
 
 | RFC | Title | Lines | Description |
 |-----|-------|-------|-------------|
-| [KTP-RECOVERY](rfcs/ktp-recovery.txt) | Disaster Recovery | 932 | Backup/restore, key ceremonies, zone recovery, split-brain resolution |
-| [KTP-MIGRATION](rfcs/ktp-migration.txt) | Migration Guide | 1,042 | Adoption pathways, legacy integration, staged deployment |
+| [KTP-Recovery](rfcs/ktp-recovery.md) | Disaster Recovery & Resilience | 1,174 | Backup/restore, key ceremonies, zone recovery, split-brain resolution |
+| [KTP-Migration](rfcs/ktp-migration.md) | Migration Guide | 1,216 | Adoption pathways, staged deployment |
+| [KTP-Legacy](rfcs/ktp-legacy.md) | Legacy System Integration | 870 | OAuth 2.0 / OIDC / SAML / mTLS bridges, trust equivalence mapping |
+| [KTP-Deprecation](rfcs/ktp-deprecation.md) | End-of-Life Specification | 785 | Deprecation timelines, trajectory preservation, knowledge transfer |
 
 ### Human & Governance
 
 | RFC | Title | Lines | Description |
 |-----|-------|-------|-------------|
-| [KTP-HUMAN](rfcs/ktp-human.txt) | Human Integration | 1,178 | Humans as agents, collaboration patterns, system ethics |
-| [KTP-GOVERNANCE](rfcs/ktp-governance.txt) | Specification Governance | 654 | Stewardship council, amendment process, anti-capture provisions |
+| [KTP-Human](rfcs/ktp-human.md) | Human Integration | 1,305 | Humans as agents, collaboration patterns, system ethics |
+| [KTP-Relational](rfcs/ktp-relational.md) | Relational Dynamics | 381 | The Va, indigenous relational concepts, relationship repair, ceremony |
+| [KTP-Governance](rfcs/ktp-governance.md) | Specification Governance | 890 | Stewardship council, amendment process, anti-capture provisions |
 
 ### Privacy & Compliance
 
 | RFC | Title | Lines | Description |
 |-----|-------|-------|-------------|
-| [KTP-PRIVACY](rfcs/ktp-privacy.txt) | Privacy Framework | 2,382 | GDPR, CCPA, ICCPR Article 17, privacy-preserving computation, data minimization |
-| [KTP-CONFORMANCE](rfcs/ktp-conformance.txt) | Conformance Requirements | 906 | Certification levels, testing requirements, interoperability |
+| [KTP-Privacy](rfcs/ktp-privacy.md) | Privacy Framework | 2,255 | GDPR, CCPA, ICCPR Article 17, privacy-preserving computation, data minimization |
+| [KTP-Provenance](rfcs/ktp-provenance.md) | Provenance & Knowledge Debt | 1,103 | Data provenance, consent status, indigenous data principles, capability lineage |
+| [KTP-Conformance](rfcs/ktp-conformance.md) | Conformance Requirements | 1,228 | Certification levels, testing requirements, interoperability |
 
 ### Special Topics
 
 | RFC | Title | Lines | Description |
 |-----|-------|-------|-------------|
-| [KTP-CELESTIAL](rfcs/ktp-celestial.txt) | Celestial Wayfinding | 1,153 | Interplanetary trust, light-cone model, Polynesian navigation philosophy |
-| [KTP-PROBLEMS](rfcs/ktp-problems.txt) | Open Problems | 2,448 | Known limitations, anticipated critiques, honest assessment, call for collaboration |
+| [KTP-Celestial](rfcs/ktp-celestial.md) | Celestial Wayfinding | 1,125 | Interplanetary trust, light-cone model, Polynesian navigation philosophy |
+| [KTP-Problems](rfcs/ktp-problems.md) | Open Problems | 2,471 | Known limitations, anticipated critiques, honest assessment, call for collaboration |
 
 ### Summary Statistics
 
-- **Total RFC Documents**: 19
-- **Total Specification Lines**: ~24,000
+- **Total RFC Documents**: 27
+- **Total Specification Lines**: ~33,000 (RFCs + Constitution)
 - **JSON Schemas**: 4
 - **Constitutional Articles**: 10
 
@@ -236,32 +257,32 @@ KTP-PROBLEMS explicitly documents what we don't know how to solve, inviting coll
 ```
 ktp-rfc/
 ├── README.md                 # This file
+├── NOTICE                    # Apache 2.0 attribution notice
+├── CITATION.cff              # Machine-readable citation metadata
+├── PROVENANCE.md             # Attribution & citation norms
+├── LICENSE                   # Apache License 2.0
 ├── constitution.txt          # The Constitution of Digital Physics
-├── rfcs/                     # RFC specifications (19 documents)
-│   ├── ktp-core.txt          # Core protocol specification
-│   ├── ktp-identity.txt      # Vector identity and trajectory
-│   ├── ktp-sensors.txt       # Context Tensor sensors
-│   ├── ktp-enforce.txt       # Enforcement layer
-│   ├── ktp-audit.txt         # Flight Recorder
-│   ├── ktp-zones.txt         # Blue Zone discovery
-│   ├── ktp-federation.txt    # Trust federation
-│   ├── ktp-crypto.txt        # Cryptographic specification
-│   ├── ktp-transport.txt     # Transport layer
-│   ├── ktp-threat-model.txt  # Security threat model
-│   ├── ktp-recovery.txt      # Disaster recovery
-│   ├── ktp-migration.txt     # Migration guide
-│   ├── ktp-human.txt         # Human integration
-│   ├── ktp-governance.txt    # Specification governance
-│   ├── ktp-privacy.txt       # Privacy framework
-│   ├── ktp-conformance.txt   # Conformance requirements
-│   ├── ktp-celestial.txt     # Interplanetary trust
-│   └── ktp-problems.txt      # Open problems and limitations
-└── schemas/                  # JSON schemas
-    ├── trust-proof.json      # Trust Proof token schema
-    ├── context-tensor.json   # Context Tensor schema
-    ├── soul-constraint.json  # Soul constraint schema
-    └── sensor-config.json    # Sensor configuration schema
+├── glossary.md               # Term glossary
+├── rfcs/                     # RFC summary pages (27 documents, Markdown)
+│   ├── ktp-core.md           #   each summary embeds its full text from
+│   ├── ktp-identity.md       #   rfcs-txt/ via a snippet include
+│   └── ...                    #   (see the RFC Series table above)
+├── rfcs-txt/                 # Full RFC specification text (27 documents)
+│   ├── ktp-core.txt
+│   ├── ktp-identity.txt
+│   └── ...
+├── docs/                     # MkDocs documentation site sources
+│   └── schemas/              # JSON schemas
+│       ├── trust-proof.json      # Trust Proof token schema
+│       ├── context-tensor.json   # Context Tensor schema
+│       ├── soul-constraint.json  # Soul constraint schema
+│       └── sensor-config.json    # Sensor configuration schema
+├── scripts/                  # Repo tooling (e.g. rfcs↔rfcs-txt sync check)
+└── mkdocs.yml                # Documentation site configuration
 ```
+
+The paired `rfcs/*.md` (summary) and `rfcs-txt/*.txt` (full text) files are
+kept in sync by `scripts/check-rfc-sync.sh`, enforced on pull requests.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
Mechanical staleness fixes only — no canon changes.
- **Broken links:** every RFC link pointed to `rfcs/*.txt`; the full text lives in `rfcs-txt/` now. Relinked all 27 to their `rfcs/*.md` summary pages.
- **Wrong count:** "19 RFC documents" → **27**; added the 9 missing RFCs (Tensors, Signal, Gravity, Oracle, Provenance, Relational, Emergency, Deprecation, Legacy) with accurate titles + current line counts.
- **Repo-structure diagram** corrected to the real layout (`rfcs/*.md` + `rfcs-txt/*.txt` + `docs/`).
- Added the docs-site link, a **Citing KTP** note, and the provenance files (NOTICE / CITATION.cff / PROVENANCE.md) to the structure diagram.

## Deliberately left alone
The Context Tensor dimension model (7 vs. 1,707/six-domain) and the Trust Tiers table (Hibernation) — flagged as substantive canon questions for a separate pass.

## Test plan
- [x] No `rfcs/*.txt` links remain
- [x] All 27 `rfcs/*.md` link targets resolve
- [x] All provenance-file links resolve