### PR TITLE
CITATION, README: the v2.0.0 DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,9 +11,10 @@ authors:
     orcid: "https://orcid.org/0009-0003-5479-4248"
 version: "2.0.0"
 date-released: "2026-08-14"
-# No `identifiers:` block yet. VERSIONING.md makes the archive step part of
-# what a release is; the identifier is added here when the deposit for this
-# version exists, and never guessed ahead of it.
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.21938282
+    description: "The v2.0.0 Gödel release archive (Zenodo)"
 url: "https://github.com/nmcitra/ktp-rfc"
 repository-code: "https://github.com/nmcitra/ktp-rfc"
 license: "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kinetic Trust Protocol (KTP) — RFC Series
 
 **Version**: 2.0.0 *Gödel* · **Status**: Draft specification — NMCITRA  
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21938282.svg)](https://doi.org/10.5281/zenodo.21938282)  
 **First published**: November 2025 · **This release**: 14 August 2026
 
 Draft specifications developed by the New Mexico Cyber Intelligence & Threat
@@ -252,9 +253,8 @@ When your work materially uses or discusses KTP's named constructs, equations,
 or distinctive architecture, please cite it — see
 [`CITATION.cff`](CITATION.cff) and [`PROVENANCE.md`](PROVENANCE.md).
 
-`CITATION.cff` carries no `identifiers:` block yet. The archive deposit is part
-of what a release is, and the identifier is added there when the deposit for
-that version exists — never guessed ahead of it.
+The v2.0.0 release is archived at Zenodo:
+[doi.org/10.5281/zenodo.21938282](https://doi.org/10.5281/zenodo.21938282).
 
 ## Contributing
 


### PR DESCRIPTION
The Zenodo deposit for v2.0.0 exists (10.5281/zenodo.21938282, minted on Release publish); this records it, per VERSIONING.md's archive bar.