### PR TITLE
post-tag: the physics input names come out of the live prose

### DIFF
--- a/rfc-src/ktp-audit.md
+++ b/rfc-src/ktp-audit.md
@@ -40,7 +40,7 @@ The Flight Recorder solves this by recording every Silent Veto with the same det
 
 ~~~
    "At 14:32:07, Agent X attempted action Y with risk 85.
-    E_trust was 42 due to elevated Heat (0.78) from active
+    E_trust was 42 due to elevated adversarial_pressure (0.78) from active
     attack indicators. Silent Veto triggered. Action denied.
     If this action had been permitted, blast radius would have
     included 47 downstream services."

--- a/rfc-src/ktp-conformance.md
+++ b/rfc-src/ktp-conformance.md
@@ -105,7 +105,7 @@ Trust Oracle:
 
 Risk Factors:
 
-- Minimum 3 weighted inputs (Heat, Momentum, one other)
+- Minimum 3 weighted inputs (adversarial_pressure, trust_trend, one other)
 - Basic normalization (min/max scaling)
 - Single risk domain (no Node/Neighborhood/Global separation)
 

--- a/rfc-src/ktp-core.md
+++ b/rfc-src/ktp-core.md
@@ -167,7 +167,7 @@ A KTP deployment consists of the following components:
          v                    v                    v
 +------------------------------------------------------------------+
 |                      RISK FACTOR SENSORS                         |
-|  [Mass]  [Velocity]  [Heat]  [Time]  [Inertia]  [Observer]       |
+| [evidence_density] [trust_trend] [adversarial_pressure] [...]    |
 +------------------------------------------------------------------+
          |                    |                    |
          v                    v                    v
@@ -678,7 +678,7 @@ The Risk Factors are seven named measurements of the environment that drive the 
 ~~~
 
 ~~~
-   Impact: High Mass creates a Gravity Well. It naturally slows
+   Impact: high evidence_density slows the environment. It naturally slows
    down operations (Time Dilation) and increases the "cost" of
    movement through the environment.
 ~~~
@@ -710,7 +710,7 @@ The Risk Factors are seven named measurements of the environment that drive the 
 ~~~
 
 ~~~
-   Impact: High Momentum means the system is moving fast. Sudden
+   Impact: high trust_trend means standing is moving fast. Sudden
    stops or turns (Vector Kinking) create massive G-forces (Risk).
    Course corrections become expensive.
 ~~~
@@ -742,8 +742,8 @@ The Risk Factors are seven named measurements of the environment that drive the 
 ~~~
 
 ~~~
-   Impact: Heat is the Deflator. As Heat rises, the structural
-   integrity of Trust degrades. High Heat triggers the "Cool-Down"
+   Impact: adversarial_pressure is the deflator. As it rises, the
+   structural integrity of trust degrades; sustained highs trigger the "Cool-Down"
    cycle (Freezing agents to Observer Mode).
 ~~~
 
@@ -809,8 +809,8 @@ Provenance: moment_criticality is externally supplied. Six of the seven inputs a
 ~~~
 
 ~~~
-   Impact: A Core Router has high Inertia; an edge IoT device has
-   low Inertia. High Inertia nodes require higher Trust Scores to
+   Impact: a core router has high update_resistance; an edge IoT
+   device has low. High-resistance nodes require higher Trust Scores to
    modify - they resist change.
 ~~~
 
@@ -1027,14 +1027,14 @@ Example normalization thresholds:
 
 ~~~
 +------------+------------+------------+------------+
-| Dimension  | Sensor     | s_min      | s_max      |
+| Input                | Sensor     | s_min | s_max     |
 +------------+------------+------------+------------+
-| Mass       | CO2 (ppm)  | 400        | 2000       |
-| Momentum   | Link %     | 0          | 100        |
-| Heat       | WAF blocks | 0          | 10000/min  |
-| Time       | Hours out  | 72         | 0          |
-| Inertia    | Dep count  | 0          | 500        |
-| Observer   | VIP count  | 0          | 50         |
+| evidence_density     | CO2 (ppm)  | 400   | 2000      |
+| trust_trend          | Link %     | 0     | 100       |
+| adversarial_pressure | WAF blocks | 0     | 10000/min |
+| moment_criticality   | Hours out  | 72    | 0         |
+| update_resistance    | Dep count  | 0     | 500       |
+| attestation_coverage | VIP count  | 0     | 50        |
 | Soul       | N/A        | Binary (0 or 1)         |
 +------------+------------+------------+------------+
 ~~~
@@ -1207,14 +1207,14 @@ Sensor values SHOULD be refreshed at intervals appropriate to their rate of chan
 
 ~~~
 +------------+------------------------+
-| Dimension  | Recommended Interval   |
+| Input                | Recommended Interval |
 +------------+------------------------+
-| Mass       | 30-60 seconds          |
-| Momentum   | 1-5 seconds            |
-| Heat       | 1-5 seconds            |
-| Time       | 60 seconds             |
-| Inertia    | 300 seconds            |
-| Observer   | 30 seconds             |
+| evidence_density     | 30-60 seconds       |
+| trust_trend          | 1-5 seconds         |
+| adversarial_pressure | 1-5 seconds         |
+| moment_criticality   | 60 seconds          |
+| update_resistance    | 300 seconds         |
+| attestation_coverage | 30 seconds          |
 | Soul       | On-demand (per action) |
 +------------+------------------------+
 ~~~
@@ -1284,13 +1284,13 @@ KTP claims (in "ktp" object):
 ~~~
 
 ~~~
-   context: Object containing normalized sensor values
-     m: Mass (0-1)
-     p: Momentum (0-1)
-     h: Heat (0-1)
-     t: Time (0-1)
-     i: Inertia (0-1)
-     o: Observer (0-1)
+   risk_factors: Object containing the six normalized inputs
+     adversarial_pressure (0-1)
+     attestation_coverage (0-1)
+     evidence_density (0-1)
+     moment_criticality (0-1)
+     trust_trend (0-1)
+     update_resistance (0-1)
 ~~~
 
 ~~~

--- a/rfc-src/ktp-migration.md
+++ b/rfc-src/ktp-migration.md
@@ -496,11 +496,11 @@ Stage 0 sensor deployment focuses on observability:
 
 Minimum sensors:
 
-- CPU/memory utilization (Heat component)
-- Network throughput (Momentum component)
-- Active connections (Mass component)
-- Error rates (Heat component)
-- Request latency (Momentum component)
+- CPU/memory utilization (adversarial_pressure input)
+- Network throughput (trust_trend input)
+- Active connections (evidence_density input)
+- Error rates (adversarial_pressure input)
+- Request latency (trust_trend input)
 
 Do NOT deploy:
 

--- a/rfc-src/ktp-sensors.md
+++ b/rfc-src/ktp-sensors.md
@@ -344,9 +344,9 @@ Together, they create stable system behavior without sacrificing responsiveness 
 
 Analogy (informative): Mass (M) — Density / Mass (m)
 
-Concept: The sheer weight of presence in the environment. High Mass creates a Gravity Well that naturally slows operations (Time Dilation) and increases the "cost" of movement.
+Concept: The sheer weight of presence in the environment. High evidence_density naturally slows operations (Time Dilation) and increases the "cost" of movement.
 
-Impact on Trust: High Mass correlates with network congestion, increased attack surface, and reduced diagnostic capability. Actions become more expensive as the environment becomes denser.
+Impact on Trust: High evidence_density correlates with network congestion, increased attack surface, and reduced diagnostic capability. Actions become more expensive as the environment becomes denser.
 
 Sensor Feeds:
 
@@ -399,9 +399,9 @@ Example Calculation (Stadium):
 Analogy (informative): Momentum (P) — Kinetic Energy
 (KE = 1/2 mv²)
 
-Concept: The speed and direction of data flow. High Momentum means the system is moving fast. Sudden stops or turns (Vector Kinking) create massive G-forces (Risk).
+Concept: The speed and direction of data flow. High trust_trend means the system is moving fast. Sudden stops or turns (Vector Kinking) create massive G-forces (Risk).
 
-Impact on Trust: High Momentum leaves less capacity for additional load and increases the cost of course corrections. Actions that change system direction become increasingly expensive.
+Impact on Trust: High trust_trend leaves less capacity for additional load and increases the cost of course corrections. Actions that change system direction become increasingly expensive.
 
 Sensor Feeds:
 
@@ -453,9 +453,9 @@ Example Calculation (Trading Platform):
 
 Analogy (informative): Entropy / Temperature (T)
 
-Concept: The chaotic energy or friction in the system. Heat represents both active adversarial pressure and system stress. Heat is the Deflator—as Heat rises, the structural integrity of Trust degrades.
+Concept: The chaotic energy or friction in the system. adversarial_pressure represents both active adversarial stress and system stress. Heat is the Deflator—as Heat rises, the structural integrity of Trust degrades.
 
-Impact on Trust: High Heat indicates a compromised or stressed environment where agent actions may be exploited, misattributed, or cause cascading failures. High Heat triggers the "Cool-Down" cycle (Freezing agents to Observer Mode).
+Impact on Trust: High adversarial_pressure indicates a compromised or stressed environment where agent actions may be exploited, misattributed, or cause cascading failures. Sustained highs trigger the "Cool-Down" cycle (freezing agents to Observer Mode).
 
 Sensor Feeds:
 
@@ -562,7 +562,7 @@ Example Calculation (30 minutes to kickoff):
 
 Analogy (informative): Inertial Mass
 
-Concept: The topological importance of a node—how hard is it to move or stop this asset? A Core Router has high Inertia; an edge IoT device has low Inertia. High Inertia nodes resist change.
+Concept: The topological importance of a node—how hard is it to move or stop this asset? A core router has high update_resistance; an edge IoT device has low. High-resistance nodes resist change.
 
 Impact on Trust: Changes to high-inertia systems carry disproportionate risk due to cascading effects. The Trust Score required to modify a high-inertia node is higher than for low-inertia nodes.
 

--- a/rfcs-md/ktp-audit.md
+++ b/rfcs-md/ktp-audit.md
@@ -22,7 +22,7 @@ The Flight Recorder solves this by recording every Silent Veto with the same det
 
 ~~~
    "At 14:32:07, Agent X attempted action Y with risk 85.
-    E_trust was 42 due to elevated Heat (0.78) from active
+    E_trust was 42 due to elevated adversarial_pressure (0.78) from active
     attack indicators. Silent Veto triggered. Action denied.
     If this action had been permitted, blast radius would have
     included 47 downstream services."

--- a/rfcs-md/ktp-conformance.md
+++ b/rfcs-md/ktp-conformance.md
@@ -85,7 +85,7 @@ Trust Oracle:
 
 Risk Factors:
 
-- Minimum 3 weighted inputs (Heat, Momentum, one other)
+- Minimum 3 weighted inputs (adversarial_pressure, trust_trend, one other)
 - Basic normalization (min/max scaling)
 - Single risk domain (no Node/Neighborhood/Global separation)
 

--- a/rfcs-md/ktp-core.md
+++ b/rfcs-md/ktp-core.md
@@ -118,7 +118,7 @@ A KTP deployment consists of the following components:
          v                    v                    v
 +------------------------------------------------------------------+
 |                      RISK FACTOR SENSORS                         |
-|  [Mass]  [Velocity]  [Heat]  [Time]  [Inertia]  [Observer]       |
+| [evidence_density] [trust_trend] [adversarial_pressure] [...]    |
 +------------------------------------------------------------------+
          |                    |                    |
          v                    v                    v
@@ -629,7 +629,7 @@ The Risk Factors are seven named measurements of the environment that drive the 
 ~~~
 
 ~~~
-   Impact: High Mass creates a Gravity Well. It naturally slows
+   Impact: high evidence_density slows the environment. It naturally slows
    down operations (Time Dilation) and increases the "cost" of
    movement through the environment.
 ~~~
@@ -661,7 +661,7 @@ The Risk Factors are seven named measurements of the environment that drive the 
 ~~~
 
 ~~~
-   Impact: High Momentum means the system is moving fast. Sudden
+   Impact: high trust_trend means standing is moving fast. Sudden
    stops or turns (Vector Kinking) create massive G-forces (Risk).
    Course corrections become expensive.
 ~~~
@@ -693,8 +693,8 @@ The Risk Factors are seven named measurements of the environment that drive the 
 ~~~
 
 ~~~
-   Impact: Heat is the Deflator. As Heat rises, the structural
-   integrity of Trust degrades. High Heat triggers the "Cool-Down"
+   Impact: adversarial_pressure is the deflator. As it rises, the
+   structural integrity of trust degrades; sustained highs trigger the "Cool-Down"
    cycle (Freezing agents to Observer Mode).
 ~~~
 
@@ -760,8 +760,8 @@ Provenance: moment_criticality is externally supplied. Six of the seven inputs a
 ~~~
 
 ~~~
-   Impact: A Core Router has high Inertia; an edge IoT device has
-   low Inertia. High Inertia nodes require higher Trust Scores to
+   Impact: a core router has high update_resistance; an edge IoT
+   device has low. High-resistance nodes require higher Trust Scores to
    modify - they resist change.
 ~~~
 
@@ -978,14 +978,14 @@ Example normalization thresholds:
 
 ~~~
 +------------+------------+------------+------------+
-| Dimension  | Sensor     | s_min      | s_max      |
+| Input                | Sensor     | s_min | s_max     |
 +------------+------------+------------+------------+
-| Mass       | CO2 (ppm)  | 400        | 2000       |
-| Momentum   | Link %     | 0          | 100        |
-| Heat       | WAF blocks | 0          | 10000/min  |
-| Time       | Hours out  | 72         | 0          |
-| Inertia    | Dep count  | 0          | 500        |
-| Observer   | VIP count  | 0          | 50         |
+| evidence_density     | CO2 (ppm)  | 400   | 2000      |
+| trust_trend          | Link %     | 0     | 100       |
+| adversarial_pressure | WAF blocks | 0     | 10000/min |
+| moment_criticality   | Hours out  | 72    | 0         |
+| update_resistance    | Dep count  | 0     | 500       |
+| attestation_coverage | VIP count  | 0     | 50        |
 | Soul       | N/A        | Binary (0 or 1)         |
 +------------+------------+------------+------------+
 ~~~
@@ -1158,14 +1158,14 @@ Sensor values SHOULD be refreshed at intervals appropriate to their rate of chan
 
 ~~~
 +------------+------------------------+
-| Dimension  | Recommended Interval   |
+| Input                | Recommended Interval |
 +------------+------------------------+
-| Mass       | 30-60 seconds          |
-| Momentum   | 1-5 seconds            |
-| Heat       | 1-5 seconds            |
-| Time       | 60 seconds             |
-| Inertia    | 300 seconds            |
-| Observer   | 30 seconds             |
+| evidence_density     | 30-60 seconds       |
+| trust_trend          | 1-5 seconds         |
+| adversarial_pressure | 1-5 seconds         |
+| moment_criticality   | 60 seconds          |
+| update_resistance    | 300 seconds         |
+| attestation_coverage | 30 seconds          |
 | Soul       | On-demand (per action) |
 +------------+------------------------+
 ~~~
@@ -1235,13 +1235,13 @@ KTP claims (in "ktp" object):
 ~~~
 
 ~~~
-   context: Object containing normalized sensor values
-     m: Mass (0-1)
-     p: Momentum (0-1)
-     h: Heat (0-1)
-     t: Time (0-1)
-     i: Inertia (0-1)
-     o: Observer (0-1)
+   risk_factors: Object containing the six normalized inputs
+     adversarial_pressure (0-1)
+     attestation_coverage (0-1)
+     evidence_density (0-1)
+     moment_criticality (0-1)
+     trust_trend (0-1)
+     update_resistance (0-1)
 ~~~
 
 ~~~

--- a/rfcs-md/ktp-migration.md
+++ b/rfcs-md/ktp-migration.md
@@ -467,11 +467,11 @@ Stage 0 sensor deployment focuses on observability:
 
 Minimum sensors:
 
-- CPU/memory utilization (Heat component)
-- Network throughput (Momentum component)
-- Active connections (Mass component)
-- Error rates (Heat component)
-- Request latency (Momentum component)
+- CPU/memory utilization (adversarial_pressure input)
+- Network throughput (trust_trend input)
+- Active connections (evidence_density input)
+- Error rates (adversarial_pressure input)
+- Request latency (trust_trend input)
 
 Do NOT deploy:
 

--- a/rfcs-md/ktp-sensors.md
+++ b/rfcs-md/ktp-sensors.md
@@ -305,9 +305,9 @@ Together, they create stable system behavior without sacrificing responsiveness 
 
 Analogy (informative): Mass (M) — Density / Mass (m)
 
-Concept: The sheer weight of presence in the environment. High Mass creates a Gravity Well that naturally slows operations (Time Dilation) and increases the "cost" of movement.
+Concept: The sheer weight of presence in the environment. High evidence_density naturally slows operations (Time Dilation) and increases the "cost" of movement.
 
-Impact on Trust: High Mass correlates with network congestion, increased attack surface, and reduced diagnostic capability. Actions become more expensive as the environment becomes denser.
+Impact on Trust: High evidence_density correlates with network congestion, increased attack surface, and reduced diagnostic capability. Actions become more expensive as the environment becomes denser.
 
 Sensor Feeds:
 
@@ -360,9 +360,9 @@ Example Calculation (Stadium):
 Analogy (informative): Momentum (P) — Kinetic Energy
 (KE = 1/2 mv²)
 
-Concept: The speed and direction of data flow. High Momentum means the system is moving fast. Sudden stops or turns (Vector Kinking) create massive G-forces (Risk).
+Concept: The speed and direction of data flow. High trust_trend means the system is moving fast. Sudden stops or turns (Vector Kinking) create massive G-forces (Risk).
 
-Impact on Trust: High Momentum leaves less capacity for additional load and increases the cost of course corrections. Actions that change system direction become increasingly expensive.
+Impact on Trust: High trust_trend leaves less capacity for additional load and increases the cost of course corrections. Actions that change system direction become increasingly expensive.
 
 Sensor Feeds:
 
@@ -414,9 +414,9 @@ Example Calculation (Trading Platform):
 
 Analogy (informative): Entropy / Temperature (T)
 
-Concept: The chaotic energy or friction in the system. Heat represents both active adversarial pressure and system stress. Heat is the Deflator—as Heat rises, the structural integrity of Trust degrades.
+Concept: The chaotic energy or friction in the system. adversarial_pressure represents both active adversarial stress and system stress. Heat is the Deflator—as Heat rises, the structural integrity of Trust degrades.
 
-Impact on Trust: High Heat indicates a compromised or stressed environment where agent actions may be exploited, misattributed, or cause cascading failures. High Heat triggers the "Cool-Down" cycle (Freezing agents to Observer Mode).
+Impact on Trust: High adversarial_pressure indicates a compromised or stressed environment where agent actions may be exploited, misattributed, or cause cascading failures. Sustained highs trigger the "Cool-Down" cycle (freezing agents to Observer Mode).
 
 Sensor Feeds:
 
@@ -523,7 +523,7 @@ Example Calculation (30 minutes to kickoff):
 
 Analogy (informative): Inertial Mass
 
-Concept: The topological importance of a node—how hard is it to move or stop this asset? A Core Router has high Inertia; an edge IoT device has low Inertia. High Inertia nodes resist change.
+Concept: The topological importance of a node—how hard is it to move or stop this asset? A core router has high update_resistance; an edge IoT device has low. High-resistance nodes resist change.
 
 Impact on Trust: Changes to high-inertia systems carry disproportionate risk due to cascading effects. The Trust Score required to modify a high-inertia node is higher than for low-inertia nodes.
 

--- a/rfcs-txt/ktp-conformance.txt
+++ b/rfcs-txt/ktp-conformance.txt
@@ -316,7 +316,8 @@ Internet-Draft               KTP-CONFORMANCE                 August 2026
 
    Risk Factors:
 
-   *  Minimum 3 weighted inputs (Heat, Momentum, one other)
+   *  Minimum 3 weighted inputs (adversarial_pressure, trust_trend, one
+      other)
 
    *  Basic normalization (min/max scaling)
 
@@ -329,7 +330,6 @@ Internet-Draft               KTP-CONFORMANCE                 August 2026
    *  Trust Proof validation
 
    *  Binary allow/deny decisions
-
 
 
 

--- a/rfcs-txt/ktp-core.txt
+++ b/rfcs-txt/ktp-core.txt
@@ -404,7 +404,7 @@ Internet-Draft                  KTP-CORE                     August 2026
             v                    v                    v
    +------------------------------------------------------------------+
    |                      RISK FACTOR SENSORS                         |
-   |  [Mass]  [Velocity]  [Heat]  [Time]  [Inertia]  [Observer]       |
+   | [evidence_density] [trust_trend] [adversarial_pressure] [...]    |
    +------------------------------------------------------------------+
             |                    |                    |
             v                    v                    v
@@ -1383,9 +1383,9 @@ Internet-Draft                  KTP-CORE                     August 2026
       - Low evidence_density: Empty building, quiet conditions
       - High evidence_density: Packed stadium, high RF interference
 
-      Impact: High Mass creates a Gravity Well. It naturally slows
-      down operations (Time Dilation) and increases the "cost" of
-      movement through the environment.
+   Impact: high evidence_density slows the environment. It naturally slows
+   down operations (Time Dilation) and increases the "cost" of
+   movement through the environment.
 
    1.  trust_trend
 
@@ -1412,7 +1412,7 @@ Internet-Draft                  KTP-CORE                     August 2026
       - Low trust_trend: Idle system, excess capacity
       - High trust_trend: System moving fast, approaching saturation
 
-      Impact: High Momentum means the system is moving fast. Sudden
+      Impact: high trust_trend means standing is moving fast. Sudden
       stops or turns (Vector Kinking) create massive G-forces (Risk).
       Course corrections become expensive.
 
@@ -1434,9 +1434,9 @@ Internet-Draft                  KTP-CORE                     August 2026
       - Low adversarial_pressure: Cool, stable operations
       - High adversarial_pressure: Hot, active attack or system stress
 
-      Impact: Heat is the Deflator. As Heat rises, the structural
-      integrity of Trust degrades. High Heat triggers the "Cool-Down"
-      cycle (Freezing agents to Observer Mode).
+   Impact: adversarial_pressure is the deflator. As it rises, the
+   structural integrity of trust degrades; sustained highs trigger the "Cool-Down"
+   cycle (Freezing agents to Observer Mode).
 
    1.  moment_criticality
 
@@ -1496,9 +1496,9 @@ Internet-Draft                  KTP-CORE                     August 2026
       - High update_resistance: Core service, many dependencies,
         expensive to move
 
-      Impact: A Core Router has high Inertia; an edge IoT device has
-      low Inertia. High Inertia nodes require higher Trust Scores to
-      modify - they resist change.
+    Impact: a core router has high update_resistance; an edge IoT
+    device has low. High-resistance nodes require higher Trust Scores to
+    modify - they resist change.
 
    1.  attestation_coverage
 
@@ -1739,14 +1739,14 @@ Internet-Draft                  KTP-CORE                     August 2026
 
 
    +------------+------------+------------+------------+
-   | Dimension  | Sensor     | s_min      | s_max      |
+   | Input                | Sensor     | s_min | s_max     |
    +------------+------------+------------+------------+
-   | Mass       | CO2 (ppm)  | 400        | 2000       |
-   | Momentum   | Link %     | 0          | 100        |
-   | Heat       | WAF blocks | 0          | 10000/min  |
-   | Time       | Hours out  | 72         | 0          |
-   | Inertia    | Dep count  | 0          | 500        |
-   | Observer   | VIP count  | 0          | 50         |
+   | evidence_density     | CO2 (ppm)  | 400   | 2000      |
+   | trust_trend          | Link %     | 0     | 100       |
+   | adversarial_pressure | WAF blocks | 0     | 10000/min |
+   | moment_criticality   | Hours out  | 72    | 0         |
+   | update_resistance    | Dep count  | 0     | 500       |
+   | attestation_coverage | VIP count  | 0     | 50        |
    | Soul       | N/A        | Binary (0 or 1)         |
    +------------+------------+------------+------------+
 
@@ -1968,14 +1968,14 @@ Internet-Draft                  KTP-CORE                     August 2026
    rate of change:
 
    +------------+------------------------+
-   | Dimension  | Recommended Interval   |
+   | Input                | Recommended Interval |
    +------------+------------------------+
-   | Mass       | 30-60 seconds          |
-   | Momentum   | 1-5 seconds            |
-   | Heat       | 1-5 seconds            |
-   | Time       | 60 seconds             |
-   | Inertia    | 300 seconds            |
-   | Observer   | 30 seconds             |
+   | evidence_density     | 30-60 seconds       |
+   | trust_trend          | 1-5 seconds         |
+   | adversarial_pressure | 1-5 seconds         |
+   | moment_criticality   | 60 seconds          |
+   | update_resistance    | 300 seconds         |
+   | attestation_coverage | 30 seconds          |
    | Soul       | On-demand (per action) |
    +------------+------------------------+
 
@@ -2082,13 +2082,13 @@ Internet-Draft                  KTP-CORE                     August 2026
       de_dt: Trust Velocity (change per second)
       sigma: Trust Volatility (standard deviation)
 
-      context: Object containing normalized sensor values
-        m: Mass (0-1)
-        p: Momentum (0-1)
-        h: Heat (0-1)
-        t: Time (0-1)
-        i: Inertia (0-1)
-        o: Observer (0-1)
+      risk_factors: Object containing the six normalized inputs
+        adversarial_pressure (0-1)
+        attestation_coverage (0-1)
+        evidence_density (0-1)
+        moment_criticality (0-1)
+        trust_trend (0-1)
+        update_resistance (0-1)
 
       soul: Object containing sovereignty evaluation
         s: Soul veto status (0 = clear, 1 = veto)


### PR DESCRIPTION
Found by Chris post-tag (ktp-conformance:108). The class the checkers never had rules for — bare physics words as live input names — closed across six files; sanctioned senses left alone. All gates green.